### PR TITLE
Specify an (optional) private leaderboardId as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this line somewhere in your `README.md`:
 Make a note of your user ID and add your session cookie to your repo as a secret called `AOC_SESSION`.
 To see how to find these values, see those sections in the spec below.
 
-Add this action to your repo as `.github/workflows/readme-stars.yml`, pasting in yout user ID instead of 1234567:
+Add this action to your repo as `.github/workflows/readme-stars.yml`, pasting in your user ID instead of 1234567:
 
 ```yml
 name: Update README ⭐
@@ -55,20 +55,6 @@ If you want to adjust the cron expression, please remember to schedule your jobs
 
 ## Action Spec
 
-### `leaderboardId`
-
-**Optional**
-
-Your Advent of Code leaderboard ID.
-To get this, go to your Go to [leaderboard](https://adventofcode.com/2020/leaderboard/private) and press 'View'.
-The leaderboard ID is at the end of the URL:
-
-```
-https://adventofcode.com/2021/leaderboard/private/view/(leaderboard ID)
-```
-
-If not provided it will be derived from the userId parameter
-
 ### `userId`
 
 **Required**
@@ -91,6 +77,18 @@ Your Advent of Code session cookie.
 To get this, press F12 anywhere on the Advent of Code website to open your browser developer tools.
 Look in your Cookies under the Application or Storage tab, and copy out the session cookie.
 This should be stored as a repository secret, not pasted directly into the action or any other publicly viewable place.
+
+### `leaderboardId`
+
+*Optional* - default `userId` value
+
+Your Advent of Code leaderboard ID.
+To get this, go to your Go to [leaderboard](https://adventofcode.com/2020/leaderboard/private) and press 'View'.
+The leaderboard ID is at the end of the URL:
+
+```
+https://adventofcode.com/2021/leaderboard/private/view/(leaderboard ID)
+```
 
 ### `tableMarker`
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ jobs:
       - uses: k2bd/advent-readme-stars@v1
         with:
           userId: 1234567
+          leaderboardId: 9876543
           sessionCookie: ${{ secrets.AOC_SESSION }}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
@@ -54,17 +55,33 @@ If you want to adjust the cron expression, please remember to schedule your jobs
 
 ## Action Spec
 
+### `leaderboardId`
+
+**Optional**
+
+Your Advent of Code leaderboard ID.
+To get this, go to your Go to [leaderboard](https://adventofcode.com/2020/leaderboard/private) and press 'View'.
+The leaderboard ID is at the end of the URL:
+
+```
+https://adventofcode.com/2021/leaderboard/private/view/(leaderboard ID)
+```
+
+If not provided it will be derived from the userId parameter
+
 ### `userId`
 
 **Required**
 
 Your Advent of Code user ID.
-To get this, go to your Go to [leaderboard](https://adventofcode.com/2020/leaderboard/private) and press 'View'.
-Your ID is at the end of the URL:
+To get this, go to your Go to [settings](https://adventofcode.com/2021/settings).
+The user ID is displayed in the first option of the question "What would you like to be called?":
 
 ```
-https://adventofcode.com/2021/leaderboard/private/view/(your ID)
+( ) (anonymous user #<your ID>)
+( ) ....
 ```
+
 
 ### `sessionCookie`
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ runs:
   using: docker
   image: Dockerfile
 inputs:
+  leaderboardId:
+    description: >
+      AoC leaderboard ID. See the README for instructions on getting this.
+    required: false
   userId:
     description: >
       AoC user ID. See the README for instructions on getting this.

--- a/src/advent_readme_stars/constants.py
+++ b/src/advent_readme_stars/constants.py
@@ -5,6 +5,9 @@ from advent_readme_stars.advent import most_recent_advent_year
 #: Advent of Code user ID
 USER_ID = os.environ.get("INPUT_USERID", "")
 
+#: Advent of Code private leaderboard ID
+LEADERBOARD_ID = os.environ.get("INPUT_LEADERBOARDID", USER_ID)
+
 #: Advent of Code session cookie
 SESSION_COOKIE = os.environ.get("INPUT_SESSIONCOOKIE", "")
 
@@ -27,4 +30,4 @@ README_LOCATION = os.environ.get("INPUT_READMELOCATION", "")
 ADVENT_URL = os.environ.get("ADVENT_URL", "https://adventofcode.com")
 
 #: Stars info endpoint
-STARS_ENDPOINT = f"{ADVENT_URL}/{YEAR}/leaderboard/private/view/{USER_ID}.json"
+STARS_ENDPOINT = f"{ADVENT_URL}/{YEAR}/leaderboard/private/view/{LEADERBOARD_ID}.json"


### PR DESCRIPTION
This PR enriches the action by allowing to specify the Advent of Code private leaderboard ID to handle the scenario when a user has joined a private leaderboard created by another user (the private leaderboard id URL includes the id of the user that created the leaderboard).

The leaderboard ID input parameter is optional and if left blank it is defaulted to the userId, in order to maintain backwards compatibility.
