### PR TITLE
Use `pip` for installing docker dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,9 @@ ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONUNBUFFERED=1
 
-RUN pip install "poetry==1.1.11"
+COPY src .
+COPY pyproject.toml .
 
-COPY poetry.lock pyproject.toml ./
-RUN poetry install --no-dev
-
-COPY . .
-RUN poetry build && pip install dist/*.whl
+RUN pip install -e .
 
 CMD ["python", "-m", "advent_readme_stars"]


### PR DESCRIPTION
This changes the Dockerfile to use `pip` for installing dependencies instead of `poetry`. This saves time by avoiding to having to install poetry in the container.

closes #7