### PR TITLE
Updating dependency so it uses node 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
   update-readme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: k2bd/advent-readme-stars@v1
         with:
           userId: 1234567


### PR DESCRIPTION
actions/checkout@v2 uses node 12, which results in a warning that reads:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2

Luckily, actions/checkout@v3 uses node 16. This is a non-breaking change.