### PR TITLE
Add a solutions column

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ Location of the README file to edit.
 
 *Optional* - default is none
 
-Location of the solution files relative to the readmeLocation, use `{}` to indicate where the day should be inserted.
+Location of the solution files relative to the `readmeLocation`,
+the following placeholders can be used:
 
-### `solutionPadding`
-
-*Optional* - default `true`
-
-Whether the day for each solution should be padded. If true it will convert day 1 to `01`.
+- `{d}` The day of the solution (e.g. 3, 5 and 10)
+- `{dd}` The padded day of the solution (e.g. 03, 05 and 10)
+- `{yyyy}` The year of the solution (e.g. 2021 or 2023)
+- `{yy}` The truncated year of the solution (e.g. 21 or 23)
 
 ## Like this project?
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ Should be some kind of Markdown header level.
 
 Location of the README file to edit.
 
+### `solutionLocations`
+
+*Optional* - default is none
+
+Location of the solution files relative to the readmeLocation, use `{}` to indicate where the day should be inserted.
+
+### `solutionPadding`
+
+*Optional* - default `true`
+
+Whether the day for each solution should be padded. If true it will convert day 1 to `01`.
+
 ## Like this project?
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/purple_img.png)](https://www.buymeacoffee.com/k2bd)

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,14 @@ inputs:
     description: Location of the README file
     required: false
     default: "README.md"
+  solutionLocations:
+    description: Location of your solution for each day
+    required: false
+    default: ""
+  solutionPadding:
+    description: If you have enabled solution locations should each day be padded?
+    required: false
+    default: "true"
 branding:
   icon: "star"
   color: "purple"

--- a/action.yml
+++ b/action.yml
@@ -52,10 +52,6 @@ inputs:
     description: Location of your solution for each day
     required: false
     default: ""
-  solutionPadding:
-    description: If you have enabled solution locations should each day be padded?
-    required: false
-    default: "true"
 branding:
   icon: "star"
   color: "purple"

--- a/src/advent_readme_stars/constants.py
+++ b/src/advent_readme_stars/constants.py
@@ -31,3 +31,7 @@ ADVENT_URL = os.environ.get("ADVENT_URL", "https://adventofcode.com")
 
 #: Stars info endpoint
 STARS_ENDPOINT = f"{ADVENT_URL}/{YEAR}/leaderboard/private/view/{LEADERBOARD_ID}.json"
+
+SOLUTION_LOCATIONS = os.environ.get("INPUT_SOLUTIONLOCATIONS", "")
+
+SOLUTION_PADDING = os.environ.get("INPUT_SOLUTIONPADDING", "")

--- a/src/advent_readme_stars/constants.py
+++ b/src/advent_readme_stars/constants.py
@@ -33,5 +33,3 @@ ADVENT_URL = os.environ.get("ADVENT_URL", "https://adventofcode.com")
 STARS_ENDPOINT = f"{ADVENT_URL}/{YEAR}/leaderboard/private/view/{LEADERBOARD_ID}.json"
 
 SOLUTION_LOCATIONS = os.environ.get("INPUT_SOLUTIONLOCATIONS", "")
-
-SOLUTION_PADDING = os.environ.get("INPUT_SOLUTIONPADDING", "")

--- a/src/advent_readme_stars/update.py
+++ b/src/advent_readme_stars/update.py
@@ -104,7 +104,7 @@ def get_solution(day: int) -> str:
     Gets the solution text for a specific day
     """
     day_text = str(day).rjust(2 if SOLUTION_PADDING.lower() == "true" else 1, "0")
-    solution_rel_path = SOLUTION_LOCATIONS.format(day_text)
+    solution_rel_path = SOLUTION_LOCATIONS.replace("{}", str(day_text))
     readme_dir = README_LOCATION.removesuffix(os.path.basename(README_LOCATION))
     solution_location = os.path.join(readme_dir, solution_rel_path)
     if os.path.exists(solution_location):

--- a/src/advent_readme_stars/update.py
+++ b/src/advent_readme_stars/update.py
@@ -1,8 +1,12 @@
+import os.path
 from typing import List
 
 from advent_readme_stars.constants import (
     ADVENT_URL,
     HEADER_PREFIX,
+    README_LOCATION,
+    SOLUTION_LOCATIONS,
+    SOLUTION_PADDING,
     STAR_SYMBOL,
     TABLE_MARKER,
     YEAR,
@@ -62,11 +66,60 @@ def insert_table(lines: List[str]) -> List[str]:
     return lines[:table_location] + to_insert + lines[table_location:]
 
 
+def insert_solutions_table(lines: List[str]) -> List[str]:
+    """
+    Search the lines for a table marker,
+    and insert a table with links to the solutions there.
+    """
+    table_location = None
+    for i, line in enumerate(lines):
+        if line.strip() == TABLE_MARKER:
+            table_location = i
+            break
+    else:
+        return lines
+
+    to_insert = [
+        TABLE_MARKER,
+        f"{HEADER_PREFIX} {YEAR} Results",
+        "",
+        "| Day | Solution | Part 1 | Part 2 |",
+        "| :---: | :---: | :---: | :---: |",
+    ]
+    stars_info = sorted(list(get_progress()), key=lambda p: p.day)
+
+    for star_info in stars_info:
+        day_url = f"{ADVENT_URL}/{YEAR}/day/{star_info.day}"
+        day_text = f"[Day {star_info.day}]({day_url})"
+        part_1_text = STAR_SYMBOL if star_info.part_1 else " "
+        part_2_text = STAR_SYMBOL if star_info.part_2 else " "
+        solution = get_solution(star_info.day)
+        to_insert.append(f"| {day_text} | {solution} | {part_1_text} | {part_2_text} |")
+
+    return lines[:table_location] + to_insert + lines[table_location:]
+
+
+def get_solution(day: int) -> str:
+    """
+    Gets the solution text for a specific day
+    """
+    day_text = str(day).rjust(2 if SOLUTION_PADDING.lower() == "true" else 1, "0")
+    solution_rel_path = SOLUTION_LOCATIONS.format(day_text)
+    readme_dir = README_LOCATION.removesuffix(os.path.basename(README_LOCATION))
+    solution_location = os.path.join(readme_dir, solution_rel_path)
+    if os.path.exists(solution_location):
+        file_name = os.path.basename(solution_location)
+        return f"[{file_name}]({solution_rel_path})"
+    else:
+        return ""
+
+
 def update_readme(readme: List[str]) -> List[str]:
     """
     Take the contents of a readme file and update them
     """
     reduced = remove_existing_table(readme)
-    new_readme = insert_table(reduced)
-
-    return new_readme
+    if SOLUTION_LOCATIONS != "":
+        return insert_solutions_table(reduced)
+    else:
+        return insert_table(reduced)

--- a/src/advent_readme_stars/update.py
+++ b/src/advent_readme_stars/update.py
@@ -6,7 +6,6 @@ from advent_readme_stars.constants import (
     HEADER_PREFIX,
     README_LOCATION,
     SOLUTION_LOCATIONS,
-    SOLUTION_PADDING,
     STAR_SYMBOL,
     TABLE_MARKER,
     YEAR,
@@ -93,18 +92,21 @@ def insert_solutions_table(lines: List[str]) -> List[str]:
         day_text = f"[Day {star_info.day}]({day_url})"
         part_1_text = STAR_SYMBOL if star_info.part_1 else " "
         part_2_text = STAR_SYMBOL if star_info.part_2 else " "
-        solution = get_solution(star_info.day)
+        solution = get_solution(YEAR, star_info.day)
         to_insert.append(f"| {day_text} | {solution} | {part_1_text} | {part_2_text} |")
 
     return lines[:table_location] + to_insert + lines[table_location:]
 
 
-def get_solution(day: int) -> str:
+def get_solution(year: int, day: int) -> str:
     """
     Gets the solution text for a specific day
     """
-    day_text = str(day).rjust(2 if SOLUTION_PADDING.lower() == "true" else 1, "0")
-    solution_rel_path = SOLUTION_LOCATIONS.replace("{}", str(day_text))
+    solution_rel_path = (SOLUTION_LOCATIONS
+                         .replace("{d}", str(day))
+                         .replace("{dd}", str(day).rjust(2, "0"))
+                         .replace("{yyyy}", str(year))
+                         .replace("{yy}", str(year)[-2:]))
     readme_dir = README_LOCATION.removesuffix(os.path.basename(README_LOCATION))
     solution_location = os.path.join(readme_dir, solution_rel_path)
     if os.path.exists(solution_location):


### PR DESCRIPTION
This PR adds an extra solution column that directly links to your solution file for the specific day. 

Here someone has committed day 1 in their repo but has yet to commit day 2:
| Day | Solution | Part 1 | Part 2 |
| :---: | :---: | :---: | :---: |
| [Day 1](https://adventofcode.com/2022/day/1) | [01.rs](src/bin/01.rs) | ⭐ | ⭐ |
| [Day 2](https://adventofcode.com/2022/day/2) |  | ⭐ | ⭐ |

To facilitate this two new options were added to the Action:
- solutionLocations which allows you to specify where each solution would be located relative to the readme file. (in the form "src/bin/{}.rs")
- solutionPadding which can optionally pad your day numbers (1 becomes 01)

Unfortunately I was unable to create any tests (but I have tested locally) as the test framework just errors with `TypeError: required field "lineno" missing from alias`. 